### PR TITLE
devcontainerを追加

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/base:bullseye
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends postgresql-client
+
+RUN echo "alias psql='/usr/bin/psql -h db -p 5432 -U postgres -d postgres'" >> /etc/bash.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "name": "TMU L0119",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "postCreateCommand": "psql -h db -p 5432 -U postgres -d postgres -f init.sql"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ../..:/workspaces:cached
+    command: sleep infinity
+    network_mode: service:db
+
+  db:
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_HOST_AUTH_METHOD: trust
+
+volumes:
+  postgres-data:

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,28 @@
+CREATE TABLE vineyard(
+    dID VARCHAR(4) PRIMARY KEY,
+    district VARCHAR(30)
+);
+
+INSERT INTO vineyard(dID,district)
+VALUES
+    ('A','ブルゴーニュ'),
+    ('B','ボルドー'),
+    ('C','ロワール'),
+    ('D','シャンバーニュ'),
+    ('E','チリ');
+
+CREATE TABLE wine(
+    wID INTEGER PRIMARY KEY,
+    name VARCHAR(30),
+    dID VARCHAR(4) REFERENCES vineyard(dID),
+    price INTEGER
+);
+
+INSERT INTO wine(wID,name,dID,price)
+VALUES
+    (1,'シャブリ','A',2400),
+    (2,'ジュヴレシャンベルタン','A',3000),
+    (3,'サンテミリオン','B',5800),
+    (4,'オーメドック','B',2200),
+    (5,'サンセール','C',2800),
+    (6,'シャンパン','D',4000);


### PR DESCRIPTION
[devcontainer](https://containers.dev/)を導入することによって、PostgreSQLのセットアップを簡単にできます。

- [VSCode](https://code.visualstudio.com/)の場合
  - [こちらの手順](https://code.visualstudio.com/docs/devcontainers/containers)でdevcontainerを設定してください
  - すでに設定済みの場合は、このリポジトリを開くと、右下に「コンテナで開く」というボタンが表示されます
- [Codespaces](https://github.co.jp/features/codespaces)の場合
  - Codespacesはdevcontainerに対応しているので、「Create codespace」を押すだけです

---

Codespacesの使い方：

https://github.com/YokoyamaLab/Database/assets/98276492/9664c398-ba2f-4dab-a8ed-af9e20b9d5d5

